### PR TITLE
Use process substutution instead of the -c flag for sh in the setup instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ iwr "https://raw.githubusercontent.com/Vencord/Installer/main/install.ps1" -UseB
 Run the following command in your terminal and follow along with the instructions/prompts
 
 ```sh
-sh -c "$(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"
+sh <(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)
 ```
 
 ### MacOs


### PR DESCRIPTION
It's the reccommended way, and is POSIX compatible