### PR TITLE
Update find_discord_darwin.go to check for home folder

### DIFF
--- a/find_discord_darwin.go
+++ b/find_discord_darwin.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	path "path/filepath"
 	"strings"
 )
@@ -17,6 +18,21 @@ var macosNames = map[string]string{
 	"ptb":    "Discord PTB.app",
 	"canary": "Discord Canary.app",
 	"dev":    "Discord Development.app",
+}
+
+// Function to check if a file exists
+func ExistsFile(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+// Function to expand ~ in a path to the home directory
+func ExpandTilde(path string) string {
+	if strings.HasPrefix(path, "~") {
+		home, _ := os.UserHomeDir()
+		return strings.Replace(path, "~", home, 1)
+	}
+	return path
 }
 
 func ParseDiscord(p, branch string) *DiscordInstall {
@@ -46,6 +62,8 @@ func ParseDiscord(p, branch string) *DiscordInstall {
 
 func FindDiscords() []any {
 	var discords []any
+
+	// Check /Applications folder
 	for branch, dirname := range macosNames {
 		p := "/Applications/" + dirname
 		if discord := ParseDiscord(p, branch); discord != nil {
@@ -53,6 +71,17 @@ func FindDiscords() []any {
 			discords = append(discords, discord)
 		}
 	}
+
+	// Check ~/Applications folder
+	homeApplications := ExpandTilde("~/Applications")
+	for branch, dirname := range macosNames {
+		p := path.Join(homeApplications, dirname)
+		if discord := ParseDiscord(p, branch); discord != nil {
+			fmt.Println("Found Discord Install at", p)
+			discords = append(discords, discord)
+		}
+	}
+
 	return discords
 }
 


### PR DESCRIPTION
Full disclaimer: I have not checked this code nor am I strong in Golang. I simply asked ChatGPT to include application home folder search as that's where I have my discord installed and the home user's Application directory is a standard directory in macOS that exists when you first initialize your machine.