### PR TITLE
Add Mac Arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,59 @@ jobs:
           name: VencordInstaller-macos
           path: VencordInstaller.MacOS.zip
 
+  build-mac-arm64:
+    runs-on: macos-latest
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - id: go-cache-paths
+        run: |
+          echo "go_build=$(go env GOCACHE)" >> $GITHUB_ENV
+          echo "go_mod=$(go env GOMODCACHE)" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-arm64-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-go-
+
+      - name: Install dependencies
+        run: brew install pkg-config sdl2
+
+      - name: Install Go dependencies
+        run: go get -v
+
+      - name: Build
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags static -ldflags "-s -w -X 'main.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'main.InstallerTag=${{ github.ref_name }}'"
+
+      - name: Update executable
+        run: |
+          chmod +x VencordInstaller
+
+      - name: Generate MacOS arm64 bundle
+        run: |
+          mkdir -p VencordInstaller.app/Contents/MacOS
+          mkdir -p VencordInstaller.app/Contents/Resources
+          cp macos/Info.plist VencordInstaller.app/Contents/Info.plist
+          mv VencordInstaller VencordInstaller.app/Contents/MacOS/VencordInstaller
+          cp macos/icon.icns VencordInstaller.app/Contents/Resources/icon.icns
+          zip -r VencordInstaller.MacOS-arm64.zip VencordInstaller.app
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: VencordInstaller-macos-arm64
+          path: VencordInstaller.MacOS-arm64.zip
 
   build-windows:
     runs-on: windows-latest
@@ -182,7 +235,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [build-linux, build-mac, build-windows]
+    needs: [build-linux, build-mac, build-mac-arm64, build-windows]
 
     steps:
       - name: Checkout code
@@ -200,6 +253,11 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
+          name: VencordInstaller-macos-arm64
+          path: macos-arm64
+
+      - uses: actions/download-artifact@v3
+        with:
           name: VencordInstaller-windows
           path: windows
 
@@ -214,4 +272,5 @@ jobs:
           files: |
             linux/VencordInstalle*
             macos/VencordInstaller.MacOS.zip
+            macos-arm64/VencordInstaller.MacOS-arm64.zip
             windows/VencordInstalle*.exe


### PR DESCRIPTION
Avoid need to install rosetta for arm64 on macos
(haven't tested yet)