### PR TITLE
feat(MacOs): also search in $HOME/Applications for Discord

### DIFF
--- a/find_discord_darwin.go
+++ b/find_discord_darwin.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"os"
 	path "path/filepath"
 	"strings"
 )
@@ -45,11 +46,17 @@ func ParseDiscord(p, branch string) *DiscordInstall {
 
 func FindDiscords() []any {
 	var discords []any
+	bases := []string{
+		"/Applications",
+		path.Join(os.Getenv("HOME"), "Applications"),
+	}
 	for branch, dirname := range macosNames {
-		p := "/Applications/" + dirname
-		if discord := ParseDiscord(p, branch); discord != nil {
-			Log.Debug("Found Discord Install at", p)
-			discords = append(discords, discord)
+		for _, base := range bases {
+			p := path.Join(base, dirname)
+			if discord := ParseDiscord(p, branch); discord != nil {
+				Log.Debug("Found Discord Install at", p)
+				discords = append(discords, discord)
+			}
 		}
 	}
 	return discords


### PR DESCRIPTION
Installing applications in $HOME/Applications is pretty common, so lets auto-find discord in there too!

<img width="1200" alt="image" src="https://github.com/Vencord/Installer/assets/40232557/ab2b5459-e4ee-4613-bda9-2c0aca3618c7">
