### PR TITLE
feat: add option to launch discord

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -52,6 +52,7 @@ func main() {
 	var uninstallFlag = flag.Bool("uninstall", false, "Uninstall Vencord")
 	var installOpenAsarFlag = flag.Bool("install-openasar", false, "Install OpenAsar")
 	var uninstallOpenAsarFlag = flag.Bool("uninstall-openasar", false, "Uninstall OpenAsar")
+	var launchDiscordFlag = flag.Bool("launch-discord", false, "Launch Discord")
 	var locationFlag = flag.String("location", "", "The location of the Discord install to modify")
 	var branchFlag = flag.String("branch", "", "The branch of Discord to modify [auto|stable|ptb|canary]")
 	flag.Parse()
@@ -93,8 +94,8 @@ func main() {
 		}
 	}
 
-	install, uninstall, update, installOpenAsar, uninstallOpenAsar := *installFlag, *uninstallFlag, *updateFlag, *installOpenAsarFlag, *uninstallOpenAsarFlag
-	switches := []*bool{&install, &update, &uninstall, &installOpenAsar, &uninstallOpenAsar}
+	install, uninstall, update, installOpenAsar, uninstallOpenAsar, launchDiscord := *installFlag, *uninstallFlag, *updateFlag, *installOpenAsarFlag, *uninstallOpenAsarFlag, *launchDiscordFlag
+	switches := []*bool{&install, &update, &uninstall, &installOpenAsar, &uninstallOpenAsar, &launchDiscord}
 	if !SliceContainsFunc(switches, func(b *bool) bool { return *b }) {
 		interactive = true
 
@@ -112,6 +113,7 @@ func main() {
 			"Uninstall Vencord",
 			"Install OpenAsar",
 			"Uninstall OpenAsar",
+			"Launch Discord",
 			"View Help Menu",
 			"Update Vencord Installer",
 			"Quit",
@@ -166,6 +168,8 @@ func main() {
 		} else {
 			die("OpenAsar not installed")
 		}
+	} else if launchDiscord {
+		errSilent = PromptDiscord("launch", *locationFlag, *branchFlag).launch()
 	}
 
 	if err != nil {

--- a/gui.go
+++ b/gui.go
@@ -167,6 +167,13 @@ func handleOpenAsarConfirmed() {
 	}
 }
 
+func handleLaunchDiscord() {
+	choice := getChosenInstall()
+	if choice != nil {
+		choice.launch()
+	}
+}
+
 func handleErr(di *DiscordInstall, err error, action string) {
 	if errors.Is(err, os.ErrPermission) {
 		switch runtime.GOOS {
@@ -204,6 +211,12 @@ func (di *DiscordInstall) Unpatch() {
 		handleErr(di, err, "unpatch")
 	} else {
 		g.OpenPopup("#unpatched")
+	}
+}
+
+func (di *DiscordInstall) Launch() {
+	if err := di.launch(); err != nil {
+		handleErr(di, err, "launch")
 	}
 }
 
@@ -569,6 +582,21 @@ func renderInstaller() g.Widget {
 							Size((w-40)/4, 50),
 						Tooltip("Manage OpenAsar"),
 					),
+			),
+
+			g.Dummy(0, 5),
+
+			g.Row(
+				g.Dummy((w-40)/3, 0),
+				g.Style().
+					SetColor(g.StyleColorButton, DiscordBlue).
+					To(
+						g.Button("Launch Discord").
+							OnClick(handleLaunchDiscord).
+							Size((w-40)/3, 50),
+						Tooltip("Launch the selected Discord Install"),
+					),
+				g.Dummy((w-40)/3, 0),
 			),
 		),
 

--- a/patcher.go
+++ b/patcher.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	path "path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -252,3 +253,28 @@ func (di *DiscordInstall) unpatch() error {
 }
 
 //endregion
+
+// region Launch
+
+func (di *DiscordInstall) launch() error {
+	var executableFolder = path.Join(di.appPath, "../..")
+	var executablePath string
+	if runtime.GOOS == "windows" {
+		executablePath = path.Join(executableFolder, "Discord.exe")
+	} else {
+		executablePath = path.Join(executableFolder, "Discord")
+	}
+
+	Log.Info("Launchig Discord from path: " + executablePath + "...")
+	cmd := exec.Command(executablePath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	var err = cmd.Start()
+	if err != nil {
+		return errors.New("Failed to launch Discord: " + err.Error())
+	}
+
+	return nil
+}
+
+// endregion


### PR DESCRIPTION
tested on:

- Windows
- Ubuntu (Discord installed from Flatpak)

Not sure if it would work with the `discord_arch_electron` package or not

binaries - https://github.com/SunsetTechuila/Installer/releases/tag/v1.5.0

```sh
sh -c "$(curl -sS https://raw.githubusercontent.com/SunsetTechuila/Installer/script/install.sh)"
```

<details>

<summary>Screenshot</summary>

![image](https://github.com/Vencord/Installer/assets/115353812/10418945-d7fc-477e-9d6a-213441e4101e)

</details>