### PR TITLE
Specify WHAT is running with sudo / doas

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,11 +20,11 @@ curl -sS https://github.com/Vendicated/VencordInstaller/releases/latest/download
 chmod +x "$outfile"
 
 if command -v sudo >/dev/null; then
-  echo "Running with sudo"
+  echo "Running the installer with sudo"
   sudo env "$@" "$outfile"
 elif command -v doas >/dev/null; then
-  echo "Running with doas"
+  echo "Running the installer with doas"
   doas env "$@" "$outfile"
 else
-  echo "Neither sudo nor doas were found. Please install either of them to proceed."
+  echo "Neither sudo nor doas was found. Please install either of them to proceed."
 fi


### PR DESCRIPTION
Minor change, but it really irritated me, sorry.
+ a minor grammatical fix

Just "running with sudo" isn't really enough transparency, especially for some shell script.