### PR TITLE
Manually set $XDG_CONFIG_HOME if it isn't set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ trap 'rm -f "$outfile"' EXIT
 
 echo "Downloading Installer..."
 
-set -- "XDG_CONFIG_HOME=$XDG_CONFIG_HOME"
+set -- "XDG_CONFIG_HOME=${XDG_CONFIG_HOME:=$HOME/.config}"
 
 curl -sS https://github.com/Vendicated/VencordInstaller/releases/latest/download/VencordInstallerCli-Linux \
   --output "$outfile" \


### PR DESCRIPTION
Follow XDG directory specifications regardless if `$XDG_CONFIG_HOME` is set.