### PR TITLE
support arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,11 @@ jobs:
         run: go get -v
 
       - name: Build
-        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
+        run: |
+          ldflags="-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'"
+          CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags static -ldflags "$ldflags" -o VencordInstaller.arm64
+          CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "$ldflags" -o VencordInstaller.amd64
+          lipo -create VencordInstaller.arm64 VencordInstaller.amd64 -output VencordInstaller
 
       - name: Update executable
         run: |


### PR DESCRIPTION
in [macos golden gate](https://developer.apple.com/documentation/macos-release-notes/macos-27-release-notes), rosetta was deprecated. this means that Vencord Installer can not run due to it's compatibility only with intel based macs (x64)
this release fixes that. in my opinion it's important that this gets merged so users don't have to install rosetta themselves which is unnecessary bloat